### PR TITLE
Changed frontend theme from light to grey theme

### DIFF
--- a/src/components/ThemeWrapper.tsx
+++ b/src/components/ThemeWrapper.tsx
@@ -2,11 +2,11 @@
 'use client';
 
 import { ThemeProvider, CssBaseline } from '@mui/material';
-import { lightTheme } from '../shared/theme';
+import { greyTheme } from '../shared/theme';
 
 export default function ThemeWrapper({ children }: { children: React.ReactNode }) {
     return (
-        <ThemeProvider theme={lightTheme}>
+        <ThemeProvider theme={greyTheme}>
             <CssBaseline />
             {children}
         </ThemeProvider>

--- a/src/shared/__tests__/theme.test.ts
+++ b/src/shared/__tests__/theme.test.ts
@@ -1,0 +1,34 @@
+import { greyTheme } from '../theme';
+
+describe('Grey Theme', () => {
+  it('should have grey color palette', () => {
+    expect(greyTheme.palette.mode).toBe('light');
+    expect(greyTheme.palette.background.default).toBe('#f5f5f5');
+    expect(greyTheme.palette.background.paper).toBe('#ffffff');
+  });
+
+  it('should have proper grey text colors', () => {
+    expect(greyTheme.palette.text.primary).toBe('#424242');
+    expect(greyTheme.palette.text.secondary).toBe('#757575');
+  });
+
+  it('should have grey primary color', () => {
+    expect(greyTheme.palette.primary.main).toBe('#616161');
+    expect(greyTheme.palette.primary.light).toBe('#8e8e8e');
+    expect(greyTheme.palette.primary.dark).toBe('#373737');
+  });
+
+  it('should have grey secondary color', () => {
+    expect(greyTheme.palette.secondary.main).toBe('#9e9e9e');
+    expect(greyTheme.palette.secondary.light).toBe('#cfcfcf');
+    expect(greyTheme.palette.secondary.dark).toBe('#707070');
+  });
+
+  it('should have proper component overrides for grey theme', () => {
+    const outlinedInputOverrides = greyTheme.components?.MuiOutlinedInput?.styleOverrides?.root;
+    expect(outlinedInputOverrides).toBeDefined();
+    
+    const inputLabelOverrides = greyTheme.components?.MuiInputLabel?.styleOverrides?.root;
+    expect(inputLabelOverrides).toBeDefined();
+  });
+});

--- a/src/shared/theme.ts
+++ b/src/shared/theme.ts
@@ -43,3 +43,110 @@ export const lightTheme = createTheme({
         },
     },
 });
+
+export const greyTheme = createTheme({
+    palette: {
+        mode: 'light',
+        primary: {
+            main: '#616161',
+            light: '#8e8e8e',
+            dark: '#373737',
+            contrastText: '#ffffff',
+        },
+        secondary: {
+            main: '#9e9e9e',
+            light: '#cfcfcf',
+            dark: '#707070',
+            contrastText: '#ffffff',
+        },
+        background: {
+            default: '#f5f5f5',
+            paper: '#ffffff',
+        },
+        text: {
+            primary: '#424242',
+            secondary: '#757575',
+        },
+        error: {
+            main: '#d32f2f',
+        },
+        warning: {
+            main: '#f57c00',
+        },
+        info: {
+            main: '#0288d1',
+        },
+        success: {
+            main: '#388e3c',
+        },
+    },
+    components: {
+        MuiOutlinedInput: {
+            styleOverrides: {
+                root: {
+                    color: '#424242',
+                    '& .MuiOutlinedInput-notchedOutline': {
+                        borderColor: '#9e9e9e',
+                    },
+                    '&:hover .MuiOutlinedInput-notchedOutline': {
+                        borderColor: '#616161',
+                    },
+                    '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                        borderColor: '#616161',
+                    },
+                },
+                input: {
+                    color: '#424242',
+                },
+            },
+        },
+        MuiInputLabel: {
+            styleOverrides: {
+                root: {
+                    color: '#757575',
+                    '&.Mui-focused': {
+                        color: '#616161',
+                    },
+                },
+            },
+        },
+        MuiButton: {
+            styleOverrides: {
+                root: {
+                    textTransform: 'none',
+                },
+                contained: {
+                    backgroundColor: '#616161',
+                    color: '#ffffff',
+                    '&:hover': {
+                        backgroundColor: '#424242',
+                    },
+                },
+                outlined: {
+                    borderColor: '#9e9e9e',
+                    color: '#616161',
+                    '&:hover': {
+                        borderColor: '#616161',
+                        backgroundColor: 'rgba(97, 97, 97, 0.04)',
+                    },
+                },
+            },
+        },
+        MuiCard: {
+            styleOverrides: {
+                root: {
+                    backgroundColor: '#ffffff',
+                    boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+                },
+            },
+        },
+        MuiAppBar: {
+            styleOverrides: {
+                root: {
+                    backgroundColor: '#616161',
+                    color: '#ffffff',
+                },
+            },
+        },
+    },
+});


### PR DESCRIPTION
Implemented a comprehensive grey theme for the frontend application using TDD approach. Created tests first to define the expected grey color palette, then implemented the greyTheme configuration with Material-UI theme structure. Updated ThemeWrapper component to use the new grey theme instead of the previous light theme. The grey theme includes proper color definitions for primary (#616161), secondary (#9e9e9e), background (#f5f5f5), and text colors (#424242, #757575), along with component-specific styling overrides for inputs, buttons, cards, and app bar components.