### PR TITLE
Fixed input validation issue where typing '1234a' in Monthly Income field resulted in 0 instead of extracting the numeric part (1234)

### DIFF
--- a/src/components/form/Income_ExpenseForm.tsx
+++ b/src/components/form/Income_ExpenseForm.tsx
@@ -10,9 +10,22 @@ export default function IncomeExpenseForm() {
 
     } = useFinancialStore();
 
+    const parseNumericInput = (value: string): number => {
+        // Remove all non-numeric characters except decimal point
+        const cleanValue = value.replace(/[^\d.]/g, '');
+        
+        // If empty or invalid, return 0
+        if (!cleanValue || cleanValue === '.') return 0;
+        
+        // Parse as number and ensure it's positive
+        const parsed = parseFloat(cleanValue);
+        return isNaN(parsed) ? 0 : Math.abs(parsed);
+    };
+
     const handleChange = (field: keyof typeof financialData) =>
         (e: React.ChangeEvent<HTMLInputElement>) => {
-            setFinancialData({ [field]: Number(e.target.value) || 0 });
+            const numericValue = parseNumericInput(e.target.value);
+            setFinancialData({ [field]: numericValue });
         };
 
 

--- a/src/components/form/__tests__/Income_ExpenseForm.test.tsx
+++ b/src/components/form/__tests__/Income_ExpenseForm.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import Income_ExpenseForm from '../Income_ExpenseForm';
+import { act } from 'react';
+
+// Mock the financial store
+const mockSetFinancialData = jest.fn();
+jest.mock('@/store/useFinancialStore', () => {
+  return jest.fn(() => ({
+    financialData: {
+      monthlyIncome: 0,
+      housing: 0,
+      utilities: 0,
+      food: 0,
+      transportation: 0,
+      otherExpenses: 0,
+    },
+    setFinancialData: mockSetFinancialData,
+  }));
+});
+
+describe('Income_ExpenseForm', () => {
+  beforeEach(() => {
+    mockSetFinancialData.mockClear();
+  });
+
+  it('should handle valid numeric input for monthly income', () => {
+    render(<Income_ExpenseForm />);
+    const monthlyIncomeInput = screen.getByLabelText('Monthly Income');
+    
+    act(() => {
+      fireEvent.change(monthlyIncomeInput, { target: { value: '1234' } });
+    });
+
+    expect(mockSetFinancialData).toHaveBeenCalledWith({ monthlyIncome: 1234 });
+  });
+
+  it('should handle invalid input (letters mixed with numbers) by keeping only numbers', () => {
+    render(<Income_ExpenseForm />);
+    const monthlyIncomeInput = screen.getByLabelText('Monthly Income');
+    
+    act(() => {
+      fireEvent.change(monthlyIncomeInput, { target: { value: '1234a' } });
+    });
+
+    // Should extract only the numeric part and call with 1234
+    expect(mockSetFinancialData).toHaveBeenCalledWith({ monthlyIncome: 1234 });
+  });
+
+  it('should handle input with only letters by setting to 0', () => {
+    render(<Income_ExpenseForm />);
+    const monthlyIncomeInput = screen.getByLabelText('Monthly Income');
+    
+    act(() => {
+      fireEvent.change(monthlyIncomeInput, { target: { value: 'abc' } });
+    });
+
+    expect(mockSetFinancialData).toHaveBeenCalledWith({ monthlyIncome: 0 });
+  });
+
+  it('should handle decimal numbers correctly', () => {
+    render(<Income_ExpenseForm />);
+    const monthlyIncomeInput = screen.getByLabelText('Monthly Income');
+    
+    act(() => {
+      fireEvent.change(monthlyIncomeInput, { target: { value: '1234.56' } });
+    });
+
+    expect(mockSetFinancialData).toHaveBeenCalledWith({ monthlyIncome: 1234.56 });
+  });
+
+  it('should handle negative numbers by converting to positive', () => {
+    render(<Income_ExpenseForm />);
+    const monthlyIncomeInput = screen.getByLabelText('Monthly Income');
+    
+    act(() => {
+      fireEvent.change(monthlyIncomeInput, { target: { value: '-1234' } });
+    });
+
+    expect(mockSetFinancialData).toHaveBeenCalledWith({ monthlyIncome: 1234 });
+  });
+
+  it('should handle empty input by setting to 0', () => {
+    render(<Income_ExpenseForm />);
+    const monthlyIncomeInput = screen.getByLabelText('Monthly Income');
+    
+    act(() => {
+      fireEvent.change(monthlyIncomeInput, { target: { value: '' } });
+    });
+
+    expect(mockSetFinancialData).toHaveBeenCalledWith({ monthlyIncome: 0 });
+  });
+});


### PR DESCRIPTION
The issue was in the Income_ExpenseForm component where the handleChange function used `Number(e.target.value) || 0`, which converts invalid strings like '1234a' to NaN and then to 0. I implemented a new `parseNumericInput` function that:

1. Removes all non-numeric characters except decimal points using regex `/[^\d.]/g`
2. Handles edge cases like empty strings and solo decimal points
3. Converts negative numbers to positive values using Math.abs()
4. Returns 0 for completely invalid input

This ensures that '1234a' becomes 1234, 'abc' becomes 0, and '-1234' becomes 1234, providing a better user experience.